### PR TITLE
Fix slow loading when there are many folders in contents

### DIFF
--- a/source/gui_main.cpp
+++ b/source/gui_main.cpp
@@ -38,8 +38,7 @@ GuiMain::GuiMain() {
 
     /* Iterate over contents folder. */
     for (const auto& entry : FsDirIterator(contentDir)) {
-        const char invalidTID[] = "0100";
-        if ((std::memcmp(entry.name, &invalidTID, std::strlen(invalidTID)) == 0) && (std::strlen(entry.name) == 16)) {
+        if ((*(uint32_t*)entry.name == *(uint32_t*)&"0100") && (std::strlen(entry.name) == 16)) {
             bool skip = false;
             for (size_t i = 4; i < 12; i++) { //0100000000010000-0100FFFFFFFFFFFF
                 if (entry.name[i] >= '1') {

--- a/source/gui_main.cpp
+++ b/source/gui_main.cpp
@@ -38,16 +38,8 @@ GuiMain::GuiMain() {
 
     /* Iterate over contents folder. */
     for (const auto& entry : FsDirIterator(contentDir)) {
-        if (*(uint32_t*)entry.name == *(uint32_t*)&"0100") {
-            bool skip = false;
-            for (size_t i = 4; i < 12; i++) { //0100000000010000-0100FFFFFFFFFFFF
-                if (entry.name[i] != '0') {
-                    skip = true;
-                    break;
-                }
-            }
-            if (skip) continue;
-        }
+        if (*(uint32_t*)entry.name == *(uint32_t*)&"0100" && *(uint64_t*)(&entry.name[4]) != *(uint64_t*)&"00000000")
+            continue;
         FsFile toolboxFile;
         std::snprintf(pathBuffer, FS_MAX_PATH, "/atmosphere/contents/%.*s/toolbox.json", FS_MAX_PATH - 35, entry.name);
         rc = fsFsOpenFile(&this->m_fs, pathBuffer, FsOpenMode_Read, &toolboxFile);

--- a/source/gui_main.cpp
+++ b/source/gui_main.cpp
@@ -38,10 +38,10 @@ GuiMain::GuiMain() {
 
     /* Iterate over contents folder. */
     for (const auto& entry : FsDirIterator(contentDir)) {
-        if ((*(uint32_t*)entry.name == *(uint32_t*)&"0100") && (std::strlen(entry.name) == 16)) {
+        if (*(uint32_t*)entry.name == *(uint32_t*)&"0100") {
             bool skip = false;
             for (size_t i = 4; i < 12; i++) { //0100000000010000-0100FFFFFFFFFFFF
-                if (entry.name[i] >= '1') {
+                if (entry.name[i] != '0') {
                     skip = true;
                     break;
                 }

--- a/source/gui_main.cpp
+++ b/source/gui_main.cpp
@@ -38,6 +38,17 @@ GuiMain::GuiMain() {
 
     /* Iterate over contents folder. */
     for (const auto& entry : FsDirIterator(contentDir)) {
+        const char invalidTID[] = "0100";
+        if ((std::memcmp(entry.name, &invalidTID, std::strlen(invalidTID)) == 0) && (std::strlen(entry.name) == 16)) {
+            bool skip = false;
+            for (size_t i = 4; i < 12; i++) { //0100000000010000-0100FFFFFFFFFFFF
+                if (entry.name[i] >= '1') {
+                    skip = true;
+                    break;
+                }
+            }
+            if (skip) continue;
+        }
         FsFile toolboxFile;
         std::snprintf(pathBuffer, FS_MAX_PATH, "/atmosphere/contents/%.*s/toolbox.json", FS_MAX_PATH - 35, entry.name);
         rc = fsFsOpenFile(&this->m_fs, pathBuffer, FsOpenMode_Read, &toolboxFile);


### PR DESCRIPTION
This will skip checking folders with titleids that are exclusive to Application content

If you want less gross looking code

```cpp
        const char toCompareC1[] = "0100";
        const char toCompareC2[] = "00000000";
        uint32_t toCompareI1 = 0;
        uint64_t toCompareI2 = 0;
        uint32_t namePart1 = 0;
        uint64_t namePart2 = 0;
        std::memcpy(&toCompareI1, &toCompareC1, std::strlen(toCompareC1));
        std::memcpy(&toCompareI2, &toCompareC2, std::strlen(toCompareC2));
        std::memcpy(&namePart1, entry.name, sizeof(namePart1));
        std::memcpy(&namePart2, &entry.name[4], sizeof(namePart2));
        if (toCompareI1 == namePart1 && toCompareI2 != namePart2)
            continue;
```
GCC will output exactly the same assembly in both cases as long as this bigger one is C++ code 